### PR TITLE
Don't use (<$>).

### DIFF
--- a/src/SourceMap.hs
+++ b/src/SourceMap.hs
@@ -90,7 +90,7 @@ encodeMappings sources names = go . sortBy (comparing mapGenerated) where
              result += VLQ.encode (indexOf name names - previousName)
              return (indexOf name names)
     -- Return the byte buffer.
-    toLazyByteString <$> readSTRef result
+    fmap toLazyByteString $ readSTRef result
 
   updating r f = readSTRef r >>= \x -> f x >>= writeSTRef r
   r += y = modifySTRef r (<> lazyByteString y)


### PR DESCRIPTION
I was building with stack, didn't think about building with older versions (as permitted by `.cabal` versions of `base`).

Fixes #4.